### PR TITLE
fix: fix json tag error in query

### DIFF
--- a/taos/cinterface.py
+++ b/taos/cinterface.py
@@ -438,7 +438,7 @@ def taos_fetch_block_v3(result, fields=None, field_count=None):
             raise DatabaseError("Invalid data type returned from database")
         offsets = []
         is_null = []
-        if fields[i]["type"] == FieldType.C_VARCHAR or fields[i]["type"] == FieldType.C_NCHAR:
+        if fields[i]["type"] in (FieldType.C_VARCHAR, FieldType.C_NCHAR, FieldType.C_JSON):
             offsets = taos_get_column_data_offset(result, i, num_of_rows)
             blocks[i] = CONVERT_FUNC_BLOCK_v3[fields[i]["type"]](data, is_null, num_of_rows, offsets, precision)
         else:


### PR DESCRIPTION
Fix error while querying json tag from a stable:

```
Traceback (most recent call last):
  File "/home/huolinhe/Projects/taosdata/TDengine/tests/system-test/../pytest/util/sql.py", line 85, in query
    self.queryResult = self.cursor.fetchall()
  File "/home/huolinhe/Projects/taosdata/taos-connector-python/taos/cursor.py", line 229, in fetchall
    block, num_of_rows = taos_fetch_block(self._result, self._fields)
  File "/home/huolinhe/Projects/taosdata/taos-connector-python/taos/cinterface.py", line 451, in taos_fetch_block_v3
    blocks[i] = CONVERT_FUNC_BLOCK[fields[i]["type"]](data, is_null, num_of_rows, offsets, precision)
  File "/home/huolinhe/Projects/taosdata/taos-connector-python/taos/field.py", line 219, in _crow_nchar_to_python_block
    rbyte = ctypes.cast(data + nbytes * i, ctypes.POINTER(ctypes.c_short))[:1].pop()
TypeError: unsupported operand type(s) for +: 'int' and 'list'
2022-05-22 19:57:21.185950 Exception('TypeError("unsupported operand type(s) for +: \'int\' and \'list\'")')
```

Ref: [TD-15844](https://jira.taosdata.com:18080/browse/TD-15844)