### PR TITLE
enh: mark taos-ws-py optional by extra feature 'ws'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ version = ">=0.2.0"
 python = ">=3.7,<4.0"
 optional = true
 
+[tool.poetry.extras]
+ws = ["taos-ws-py"]
+
 [tool.poetry.dev-dependencies]
 typing = "*"
 pytest = [


### PR DESCRIPTION
Example:

```
pip install taospy     # without taosws module
pip install taospy[ws] # with taosws module
```