### PR TITLE
add a patch to fix the python issue29097

### DIFF
--- a/taos/field.py
+++ b/taos/field.py
@@ -10,7 +10,10 @@ from taos.error import DatabaseError
 
 _priv_tz = None
 _utc_tz = pytz.timezone("UTC")
-_datetime_epoch = datetime.fromtimestamp(0)
+try:
+    _datetime_epoch = datetime.fromtimestamp(0)
+except OSError:
+    _datetime_epoch = datetime.fromtimestamp(86400) - timedelta(seconds=86400)
 _utc_datetime_epoch = _utc_tz.localize(datetime.utcfromtimestamp(0))
 
 


### PR DESCRIPTION
it bug will happen when using python 3.6 to python 3.7 just on windows. 
<img width="925" alt="image" src="https://github.com/taosdata/taos-connector-python/assets/19170356/bdcce49a-5ca5-43c2-bc95-523cc9847eca">

For more detailed information about  python issue29097, please refer to the following link: https://bugs.python.org/issue29097