### PR TITLE
Improve parser

### DIFF
--- a/taos/field.py
+++ b/taos/field.py
@@ -17,6 +17,7 @@ except OSError:
 _utc_datetime_epoch = _utc_tz.localize(datetime.utcfromtimestamp(0))
 _priv_datetime_epoch = None
 
+
 def set_tz(tz):
     # type: (str) -> None
     global _priv_tz, _priv_datetime_epoch

--- a/taos/field.py
+++ b/taos/field.py
@@ -15,19 +15,20 @@ try:
 except OSError:
     _datetime_epoch = datetime.fromtimestamp(86400) - timedelta(seconds=86400)
 _utc_datetime_epoch = _utc_tz.localize(datetime.utcfromtimestamp(0))
-
+_priv_datetime_epoch = None
 
 def set_tz(tz):
     # type: (str) -> None
-    global _priv_tz
+    global _priv_tz, _priv_datetime_epoch
     _priv_tz = tz
+    _priv_datetime_epoch = _utc_datetime_epoch.astimezone(_priv_tz)
 
 
 def _convert_millisecond_to_datetime(milli):
     try:
         if _priv_tz is None:
             return _datetime_epoch + timedelta(seconds=milli / 1000.0)
-        return (_utc_datetime_epoch + timedelta(seconds=milli / 1000.0)).astimezone(_priv_tz)
+        return _priv_datetime_epoch + timedelta(seconds=milli / 1000.0)
     except OverflowError:
         # catch OverflowError and pass
         print("WARN: datetime overflow!")
@@ -38,7 +39,7 @@ def _convert_microsecond_to_datetime(micro):
     try:
         if _priv_tz is None:
             return _datetime_epoch + timedelta(seconds=micro / 1000000.0)
-        return (_utc_datetime_epoch + timedelta(seconds=micro / 1000000.0)).astimezone(_priv_tz)
+        return _priv_datetime_epoch + timedelta(seconds=micro / 1000000.0)
     except OverflowError:
         # catch OverflowError and pass
         print("WARN: datetime overflow!")

--- a/taos/field_v3.py
+++ b/taos/field_v3.py
@@ -3,6 +3,40 @@ import ctypes
 
 from taos.constants import FieldType
 
+#
+# def _crow_binary_to_python_block_v3(data, is_null, num_of_rows, offsets, precision=FieldType.C_TIMESTAMP_UNKNOWN):
+#     """Function to convert C binary row to python row."""
+#     assert offsets is not None
+#     res = []
+#     for i in range(abs(num_of_rows)):
+#         if offsets[i] == -1:
+#             res.append(None)
+#         else:
+#             rbyte = ctypes.cast(data + offsets[i], ctypes.POINTER(ctypes.c_uint16))[:1].pop()
+#             chars = ctypes.cast(ctypes.c_char_p(data + offsets[i] + 2), ctypes.POINTER(ctypes.c_char * rbyte))
+#             buffer = ctypes.create_string_buffer(rbyte + 1)
+#             buffer[:rbyte] = chars[0][:rbyte]
+#             res.append(ctypes.cast(buffer, ctypes.c_char_p).value.decode("utf-8"))
+#     return res
+#
+#
+# def _crow_nchar_to_python_block_v3(data, is_null, num_of_rows, offsets, precision=FieldType.C_TIMESTAMP_UNKNOWN):
+#     """Function to convert C nchar row to python row."""
+#     assert offsets is not None
+#     res = []
+#     for i in range(abs(num_of_rows)):
+#         if offsets[i] == -1:
+#             res.append(None)
+#         else:
+#             rbyte = ctypes.cast(data + offsets[i], ctypes.POINTER(ctypes.c_uint16))[:1].pop()
+#             chars = ctypes.cast(ctypes.c_char_p(data + offsets[i] + 2), ctypes.POINTER(ctypes.c_char * rbyte))
+#             buffer = ctypes.create_string_buffer(rbyte + 1)
+#             buffer[:rbyte] = chars[0][:rbyte]
+#             res.append(ctypes.cast(buffer, ctypes.c_char_p).value.decode("utf-8"))
+#     return res
+
+_RTYPE = ctypes.c_uint16
+_RTYPE_SIZE = ctypes.sizeof(_RTYPE)
 
 def _crow_binary_to_python_block_v3(data, is_null, num_of_rows, offsets, precision=FieldType.C_TIMESTAMP_UNKNOWN):
     """Function to convert C binary row to python row."""
@@ -12,11 +46,9 @@ def _crow_binary_to_python_block_v3(data, is_null, num_of_rows, offsets, precisi
         if offsets[i] == -1:
             res.append(None)
         else:
-            rbyte = ctypes.cast(data + offsets[i], ctypes.POINTER(ctypes.c_uint16))[:1].pop()
-            chars = ctypes.cast(ctypes.c_char_p(data + offsets[i] + 2), ctypes.POINTER(ctypes.c_char * rbyte))
-            buffer = ctypes.create_string_buffer(rbyte + 1)
-            buffer[:rbyte] = chars[0][:rbyte]
-            res.append(ctypes.cast(buffer, ctypes.c_char_p).value.decode("utf-8"))
+            rbyte = _RTYPE.from_address(data + offsets[i]).value
+            chars = (ctypes.c_char * rbyte).from_address(data + offsets[i] + _RTYPE_SIZE).raw.decode("utf-8")
+            res.append(chars)
     return res
 
 
@@ -28,11 +60,9 @@ def _crow_nchar_to_python_block_v3(data, is_null, num_of_rows, offsets, precisio
         if offsets[i] == -1:
             res.append(None)
         else:
-            rbyte = ctypes.cast(data + offsets[i], ctypes.POINTER(ctypes.c_uint16))[:1].pop()
-            chars = ctypes.cast(ctypes.c_char_p(data + offsets[i] + 2), ctypes.POINTER(ctypes.c_char * rbyte))
-            buffer = ctypes.create_string_buffer(rbyte + 1)
-            buffer[:rbyte] = chars[0][:rbyte]
-            res.append(ctypes.cast(buffer, ctypes.c_char_p).value.decode("utf-8"))
+            rbyte = _RTYPE.from_address(data + offsets[i]).value
+            chars = (ctypes.c_char * rbyte).from_address(data + offsets[i] + _RTYPE_SIZE).raw.decode("utf-8")
+            res.append(chars)
     return res
 
 

--- a/taos/field_v3.py
+++ b/taos/field_v3.py
@@ -3,40 +3,10 @@ import ctypes
 
 from taos.constants import FieldType
 
-#
-# def _crow_binary_to_python_block_v3(data, is_null, num_of_rows, offsets, precision=FieldType.C_TIMESTAMP_UNKNOWN):
-#     """Function to convert C binary row to python row."""
-#     assert offsets is not None
-#     res = []
-#     for i in range(abs(num_of_rows)):
-#         if offsets[i] == -1:
-#             res.append(None)
-#         else:
-#             rbyte = ctypes.cast(data + offsets[i], ctypes.POINTER(ctypes.c_uint16))[:1].pop()
-#             chars = ctypes.cast(ctypes.c_char_p(data + offsets[i] + 2), ctypes.POINTER(ctypes.c_char * rbyte))
-#             buffer = ctypes.create_string_buffer(rbyte + 1)
-#             buffer[:rbyte] = chars[0][:rbyte]
-#             res.append(ctypes.cast(buffer, ctypes.c_char_p).value.decode("utf-8"))
-#     return res
-#
-#
-# def _crow_nchar_to_python_block_v3(data, is_null, num_of_rows, offsets, precision=FieldType.C_TIMESTAMP_UNKNOWN):
-#     """Function to convert C nchar row to python row."""
-#     assert offsets is not None
-#     res = []
-#     for i in range(abs(num_of_rows)):
-#         if offsets[i] == -1:
-#             res.append(None)
-#         else:
-#             rbyte = ctypes.cast(data + offsets[i], ctypes.POINTER(ctypes.c_uint16))[:1].pop()
-#             chars = ctypes.cast(ctypes.c_char_p(data + offsets[i] + 2), ctypes.POINTER(ctypes.c_char * rbyte))
-#             buffer = ctypes.create_string_buffer(rbyte + 1)
-#             buffer[:rbyte] = chars[0][:rbyte]
-#             res.append(ctypes.cast(buffer, ctypes.c_char_p).value.decode("utf-8"))
-#     return res
 
 _RTYPE = ctypes.c_uint16
 _RTYPE_SIZE = ctypes.sizeof(_RTYPE)
+
 
 def _crow_binary_to_python_block_v3(data, is_null, num_of_rows, offsets, precision=FieldType.C_TIMESTAMP_UNKNOWN):
     """Function to convert C binary row to python row."""


### PR DESCRIPTION
resolved #204 
### This PR improve the performance of  `taos` query[c -> python parser] :
- reduce `cast`, `memory copy` and `object creation`
- convert timezone once when `set_tz`, not everytime `_convert_XXX_to_datetime`
- totally, it take only 10%-20% cpu time when dealing with binary, nchar and timestamp

### further more
- `taos_is_null` had been called so many time per query
- a vector version of `taos_is_null` from libtaos is needed to improve this, just like `taos_get_column_data_offset`
- or maybe, introducing the third party libraries such as Cython to improve this