### PR TITLE
feat: upgrade rust connector to support IPv6

### DIFF
--- a/taos-ws-py/CHANGELOG.md
+++ b/taos-ws-py/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Conventional Changelog](https://www.conventionalcommits.org/en/v1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.3 - 2025-06-19
+
+- **(taos-ws-py)**: Upgrade Rust connector to support IPv6
+
 ## v0.5.2 - 2025-05-27
 
 - **(taos-ws-py)**: Optimization of Python connector WebSocket poll

--- a/taos-ws-py/Cargo.lock
+++ b/taos-ws-py/Cargo.lock
@@ -1331,7 +1331,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "mdsn"
 version = "0.2.25"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "itertools 0.13.0",
  "lazy_static",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "taos"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "taos-error"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2338,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "taos-macros"
 version = "0.2.16"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "taos-optin"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "taos-query"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "taos-ws"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#9c6af6de85e67f0883a7b97b2cf3b5307641b6c7"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#e93f352c96f37ae8354d1860e5886662408916ff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "taos-ws-py"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/taos-ws-py/Cargo.toml
+++ b/taos-ws-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taos-ws-py"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
# Description

Upgrade rust connector to support IPv6.

Jira: https://jira.taosdata.com:18080/browse/TD-TD-35109

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?
