### PR TITLE
chore: sync TDengine subtree updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,17 @@ English | [简体中文](./README-CN.md)
 - [1. Introduction](#1-introduction)
 - [2. Documentation](#2-documentation)
 - [3. Prerequisites](#3-prerequisites)
-- [4. Build](#4-build)
+- [4. Building](#4-building)
 - [5. Testing](#5-testing)
   - [5.1 Test Execution](#51-test-execution)
   - [5.2 Test Case Addition](#52-test-case-addition)
   - [5.3 Performance Testing](#53-performance-testing)
-- [6. CI/CD](#6-cicd)
-- [7. Submitting Issues](#7-submitting-issues)
-- [8. Submitting PRs](#8-submitting-prs)
-- [9. References](#9-references)
-- [10. License](#10-license)
+- [6. Packaging](#6-packaging)
+- [7. CI/CD](#7-cicd)
+- [8. Submitting Issues](#8-submitting-issues)
+- [9. Submitting PRs](#9-submitting-prs)
+- [10. References](#10-references)
+- [11. License](#11-license)
 
 ## 1. Introduction
 
@@ -51,44 +52,103 @@ The API for `taospy` is compliant with the Python DB API 2.0 (PEP-249). It conta
 
 ## 3. Prerequisites
 
-- Python runtime environment (taospy: Python >= 3.6.2, taos-ws-py: Python >= 3.7)
+### System Requirements
+
+- Python >= 3.7, pip
+- For `taos` native connector: TDengine client library (`libtaos.so`)
+- For `taos-ws-py`: Rust toolchain >= 1.64, maturin
 - TDengine has been deployed locally. For specific steps, please refer to [Deploy TDengine](https://docs.tdengine.com/get-started/deploy-from-package/), and taosd and taosAdapter have been started.
 
-## 4. Build
+### Installing Build Tools
 
-Download the repository code and execute the following in root directory to build develop environment:
-``` bash
-pip3 install -e ./ 
+**Ubuntu/Debian:**
+
+```bash
+sudo apt-get install -y python3 python3-pip python3-venv
+```
+
+**CentOS/RHEL:**
+
+```bash
+sudo yum install -y python3 python3-pip
+```
+
+### Installing maturin (for taos-ws-py only)
+
+```bash
+pip3 install maturin
+```
+
+## 4. Building
+
+```bash
+# taospy (pure Python)
+git clone https://github.com/taosdata/taos-connector-python.git
+cd taos-connector-python
+pip3 install -e ".[dev]"
+
+# taos-ws-py (Rust WebSocket bindings)
+cd taos-ws-py
+maturin develop    # builds and installs in current venv
+# or
+maturin build --release   # produces a wheel in target/wheels/
 ```
 
 ## 5. Testing
+
 ### 5.1 Test Execution
+
 The Python Connector testing framework is `pytest`  
 The testing directory for `taospy` is located in the root directory: tests/  
 The testing directory for `taos-ws-py` is located in the root directory: taos-ws-py/tests/  
 The test code has been written into one bash file. You can open and view the detailed testing process   
 The following command runs all test cases on Linux platform:
-``` bash
-# for taospy
+
+```bash
+# taospy
+pytest tests/
+# or
 bash ./test_taospy.sh
 ```
 
-``` bash
-# for taos-ws-py
+```bash
+# taos-ws-py
+cd taos-ws-py
+maturin develop
+pytest tests/
+cd ..
+# or
 bash ./test_taos-ws-py.sh
 ```
 
 ### 5.2 Test Case Addition
+
 You can add new test files or add test cases in existing test files that comply with `pytest` standards
 
 ### 5.3 Performance Testing
+
 Performance testing is in progress.
 
-## 6. CI/CD
+## 6. Packaging
+
+```bash
+# taospy
+python3 -m build
+# Output: dist/taospy-<version>.tar.gz, dist/taospy-<version>-py3-none-any.whl
+
+# taos-ws-py
+cd taos-ws-py
+maturin build --release
+# Output: target/wheels/taos_ws_py-<version>-*.whl
+```
+
+## 7. CI/CD
+
 - [Build Workflow](https://github.com/taosdata/taos-connector-python/actions/workflows/build.yml)
 - [Code Coverage](https://app.codecov.io/gh/taosdata/taos-connector-python)
 
-## 7. Submitting Issues
+## 8. Submitting Issues
+
 We welcome the submission of [GitHub Issue](https://github.com/taosdata/taos-connector-python/issues/new?template=Blank+issue). When submitting, please provide the following information:
 
 - Problem description, whether it always occurs, and it's best to include a detailed call stack.
@@ -96,7 +156,8 @@ We welcome the submission of [GitHub Issue](https://github.com/taosdata/taos-con
 - Python Connection parameters (username and password not required).
 - TDengine server version.
 
-## 8. Submitting PRs
+## 9. Submitting PRs
+
 We welcome developers to contribute to this project. When submitting PRs, please follow these steps:
 
 1. Fork this project, refer to ([how to fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo)).
@@ -107,9 +168,11 @@ We welcome developers to contribute to this project. When submitting PRs, please
 6. After submitting the PR, you can find your PR through the [Pull Request](https://github.com/taosdata/taos-connector-python/pulls). Click on the corresponding link to see if the CI for your PR has passed. If it has passed, it will display "All checks have passed". Regardless of whether the CI passes or not, you can click "Show all checks" -> "Details" to view the detailed test case logs.
 7. After submitting the PR, if CI passes, you can find your PR on the [codecov](https://app.codecov.io/gh/taosdata/taos-connector-python/pulls) page to check the test coverage.
 
-## 9. References
+## 10. References
+
 - [TDengine Official Website](https://www.tdengine.com/) 
 - [TDengine GitHub](https://github.com/taosdata/TDengine) 
 
-## 10. License
+## 11. License
+
 [MIT License](./LICENSE)

--- a/taos-ws-py/CHANGELOG.md
+++ b/taos-ws-py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Conventional Changelog](https://www.conventionalcommits.org/en/v1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.0 - 2026-06-29
+
+### Features:
+
+- Support taosAdapter HA.
+
 ## v0.6.9 - 2026-04-21
 
 ### Enhancements:

--- a/taos-ws-py/Cargo.lock
+++ b/taos-ws-py/Cargo.lock
@@ -1242,7 +1242,6 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "mdsn"
 version = "0.2.25"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -1824,7 +1823,7 @@ checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 [[package]]
 name = "ring"
 version = "0.17.8"
-source = "git+https://github.com/taosdata/ring.git?branch=fix%2Floongarch#2d0cfa2c570a86622f4237939b3893d6719682f1"
+source = "git+https://git.tdengine.net/taosdata/rust-deps/ring.git?branch=fix%2Floongarch#2d0cfa2c570a86622f4237939b3893d6719682f1"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2260,7 +2259,6 @@ dependencies = [
 [[package]]
 name = "taos"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2276,7 +2274,6 @@ dependencies = [
 [[package]]
 name = "taos-error"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2289,7 +2286,6 @@ dependencies = [
 [[package]]
 name = "taos-macros"
 version = "0.2.16"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2299,7 +2295,6 @@ dependencies = [
 [[package]]
 name = "taos-optin"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2325,7 +2320,6 @@ dependencies = [
 [[package]]
 name = "taos-query"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2368,7 +2362,6 @@ dependencies = [
 [[package]]
 name = "taos-ws"
 version = "0.12.4"
-source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#787eb874f86ae5d0b529556cb1b10e506f42ed7e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2385,7 +2378,6 @@ dependencies = [
  "itertools",
  "once_cell",
  "rand 0.9.2",
- "rustls",
  "scc",
  "serde",
  "serde_json",
@@ -2569,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "tokio-tungstenite"
 version = "0.23.1"
-source = "git+https://github.com/taosdata/tokio-tungstenite.git?rev=3420353#3420353b475ed1162c248cab51cd314e103bb48a"
+source = "git+https://git.tdengine.net/taosdata/rust-deps/tokio-tungstenite.git?rev=3420353#3420353b475ed1162c248cab51cd314e103bb48a"
 dependencies = [
  "futures-util",
  "log",
@@ -2646,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "tungstenite"
 version = "0.23.0"
-source = "git+https://github.com/taosdata/tungstenite-rs.git?branch=feat%2Ftaosdata%2Fpermessage-deflate#e4d146b831fe8255c669ce9984267ba3204999c5"
+source = "git+https://git.tdengine.net/taosdata/rust-deps/tungstenite-rs.git?branch=feat%2Ftaosdata%2Fpermessage-deflate#e4d146b831fe8255c669ce9984267ba3204999c5"
 dependencies = [
  "byteorder",
  "bytes",

--- a/taos-ws-py/Cargo.lock
+++ b/taos-ws-py/Cargo.lock
@@ -1823,7 +1823,7 @@ checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 [[package]]
 name = "ring"
 version = "0.17.8"
-source = "git+https://git.tdengine.net/taosdata/rust-deps/ring.git?branch=fix%2Floongarch#2d0cfa2c570a86622f4237939b3893d6719682f1"
+source = "git+https://github.com/taosdata/ring.git?branch=fix%2Floongarch#2d0cfa2c570a86622f4237939b3893d6719682f1"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "tokio-tungstenite"
 version = "0.23.1"
-source = "git+https://git.tdengine.net/taosdata/rust-deps/tokio-tungstenite.git?rev=3420353#3420353b475ed1162c248cab51cd314e103bb48a"
+source = "git+https://github.com/taosdata/tokio-tungstenite.git?rev=3420353#3420353b475ed1162c248cab51cd314e103bb48a"
 dependencies = [
  "futures-util",
  "log",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "tungstenite"
 version = "0.23.0"
-source = "git+https://git.tdengine.net/taosdata/rust-deps/tungstenite-rs.git?branch=feat%2Ftaosdata%2Fpermessage-deflate#e4d146b831fe8255c669ce9984267ba3204999c5"
+source = "git+https://github.com/taosdata/tungstenite-rs.git?branch=feat%2Ftaosdata%2Fpermessage-deflate#e4d146b831fe8255c669ce9984267ba3204999c5"
 dependencies = [
  "byteorder",
  "bytes",

--- a/taos-ws-py/Cargo.lock
+++ b/taos-ws-py/Cargo.lock
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -1926,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2377,7 +2377,8 @@ dependencies = [
  "futures-util",
  "itertools",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
+ "rustls",
  "scc",
  "serde",
  "serde_json",

--- a/taos-ws-py/Cargo.lock
+++ b/taos-ws-py/Cargo.lock
@@ -43,12 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
-dependencies = [
- "backtrace",
-]
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -1242,6 +1239,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "mdsn"
 version = "0.2.25"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -2259,6 +2257,7 @@ dependencies = [
 [[package]]
 name = "taos"
 version = "0.12.4"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2274,6 +2273,7 @@ dependencies = [
 [[package]]
 name = "taos-error"
 version = "0.12.4"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2286,6 +2286,7 @@ dependencies = [
 [[package]]
 name = "taos-macros"
 version = "0.2.16"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2295,6 +2296,7 @@ dependencies = [
 [[package]]
 name = "taos-optin"
 version = "0.12.4"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2320,6 +2322,7 @@ dependencies = [
 [[package]]
 name = "taos-query"
 version = "0.12.4"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2362,6 +2365,7 @@ dependencies = [
 [[package]]
 name = "taos-ws"
 version = "0.12.4"
+source = "git+https://github.com/taosdata/taos-connector-rust.git?branch=main#f49c37185987a3f5a893a02d04fe5db662a79c37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2394,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "taos-ws-py"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/taos-ws-py/Cargo.toml
+++ b/taos-ws-py/Cargo.toml
@@ -28,17 +28,20 @@ version = "0.17.3"
 features = ["extension-module", "anyhow", "chrono", "abi3-py37"]
 
 [target.'cfg(windows)'.dependencies]
-taos = { git = "https://github.com/taosdata/taos-connector-rust.git", branch = "main", default-features = false, version = "0.12.3", features = [
+taos = { path = "../../taos-connector-rust/taos", default-features = false, version = "0.12.3", features = [
 	"optin",
 	"ws-rustls",
 	"ws-rustls-aws-lc-crypto-provider",
 ] }
 [target.'cfg(unix)'.dependencies]
-taos = { git = "https://github.com/taosdata/taos-connector-rust.git", branch = "main", default-features = false, version = "0.12.3", features = [
+taos = { path = "../../taos-connector-rust/taos", default-features = false, version = "0.12.3", features = [
 	"optin",
 	"ws-rustls",
 	"ws-rustls-ring-crypto-provider",
 ] }
 
 [patch.crates-io]
-ring = { git = "https://github.com/taosdata/ring.git", branch = "fix/loongarch" }
+ring = { git = "https://git.tdengine.net/taosdata/rust-deps/ring.git", branch = "fix/loongarch" }
+
+[patch.'https://github.com/taosdata/tungstenite-rs.git']
+tungstenite = { git = "https://git.tdengine.net/taosdata/rust-deps/tungstenite-rs.git", branch = "feat/taosdata/permessage-deflate" }

--- a/taos-ws-py/Cargo.toml
+++ b/taos-ws-py/Cargo.toml
@@ -41,7 +41,4 @@ taos = { path = "../../taos-connector-rust/taos", default-features = false, vers
 ] }
 
 [patch.crates-io]
-ring = { git = "https://git.tdengine.net/taosdata/rust-deps/ring.git", branch = "fix/loongarch" }
-
-[patch.'https://github.com/taosdata/tungstenite-rs.git']
-tungstenite = { git = "https://git.tdengine.net/taosdata/rust-deps/tungstenite-rs.git", branch = "feat/taosdata/permessage-deflate" }
+ring = { git = "https://github.com/taosdata/ring.git", branch = "fix/loongarch" }

--- a/taos-ws-py/Cargo.toml
+++ b/taos-ws-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taos-ws-py"
-version = "0.6.9"
+version = "0.7.0"
 edition = "2021"
 publish = false
 license = "MIT"
@@ -28,13 +28,13 @@ version = "0.17.3"
 features = ["extension-module", "anyhow", "chrono", "abi3-py37"]
 
 [target.'cfg(windows)'.dependencies]
-taos = { path = "../../taos-connector-rust/taos", default-features = false, version = "0.12.3", features = [
+taos = { git = "https://github.com/taosdata/taos-connector-rust.git", branch = "main", default-features = false, version = "0.12.3", features = [
 	"optin",
 	"ws-rustls",
 	"ws-rustls-aws-lc-crypto-provider",
 ] }
 [target.'cfg(unix)'.dependencies]
-taos = { path = "../../taos-connector-rust/taos", default-features = false, version = "0.12.3", features = [
+taos = { git = "https://github.com/taosdata/taos-connector-rust.git", branch = "main", default-features = false, version = "0.12.3", features = [
 	"optin",
 	"ws-rustls",
 	"ws-rustls-ring-crypto-provider",

--- a/taos-ws-py/deny.toml
+++ b/taos-ws-py/deny.toml
@@ -34,6 +34,7 @@ wildcards = "deny"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
+    "https://github.com/taosdata/taos-connector-rust.git",
     "https://github.com/taosdata/tokio-tungstenite.git",
     "https://github.com/taosdata/tungstenite-rs.git",
     "https://github.com/taosdata/ring.git",

--- a/taos-ws-py/deny.toml
+++ b/taos-ws-py/deny.toml
@@ -1,6 +1,9 @@
 [advisories]
 unmaintained = "none"
-ignore = ["RUSTSEC-2025-0020"]
+ignore = [
+    "RUSTSEC-2025-0020",
+    "RUSTSEC-2026-0177",
+]
 
 [licenses]
 allow = [
@@ -31,7 +34,6 @@ wildcards = "deny"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
-    "https://github.com/taosdata/taos-connector-rust.git",
     "https://github.com/taosdata/tokio-tungstenite.git",
     "https://github.com/taosdata/tungstenite-rs.git",
     "https://github.com/taosdata/ring.git",

--- a/taos-ws-py/src/field.rs
+++ b/taos-ws-py/src/field.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 
-use ::taos::Field;
+use taos::Field;
 
 #[pyclass]
 pub(crate) struct TaosField {

--- a/taos-ws-py/src/lib.rs
+++ b/taos-ws-py/src/lib.rs
@@ -2,7 +2,6 @@
 
 use std::str::FromStr;
 
-use ::taos::{sync::*, RawBlock, ResultSet};
 use bigdecimal::BigDecimal;
 use chrono_tz::Tz;
 use pyo3::prelude::*;
@@ -16,6 +15,7 @@ use taos::Value::{
     BigInt, Bool, Double, Float, Geometry, Int, Json, NChar, Null, SmallInt, Timestamp, TinyInt,
     UBigInt, UInt, USmallInt, UTinyInt, VarBinary, VarChar,
 };
+use taos::{sync::*, RawBlock, ResultSet};
 
 use consumer::{Consumer, Message};
 use cursor::*;

--- a/taos-ws-py/tests/test_adapter_ha.py
+++ b/taos-ws-py/tests/test_adapter_ha.py
@@ -1,0 +1,124 @@
+import time
+import utils
+import pytest
+import taosws
+from taosws import Consumer
+
+
+@pytest.mark.skipif(utils.TEST_TD_3360, reason="skip for TD-3360")
+def test_connect_with_adapter_ha_dsn():
+    conn = taosws.connect(f"taosws://{utils.test_username()}:{utils.test_password()}@localhost:6041?adapter_ha=true")
+    try:
+        assert_server_version(conn)
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(utils.TEST_TD_3360, reason="skip for TD-3360")
+def test_connect_with_adapter_ha_kwargs():
+    conn = taosws.connect(
+        host="localhost",
+        port=6041,
+        user=utils.test_username(),
+        password=utils.test_password(),
+        adapter_ha="true",
+    )
+    try:
+        assert_server_version(conn)
+    finally:
+        conn.close()
+
+
+def assert_server_version(conn):
+    rows = list(conn.query("select server_version()"))
+    assert len(rows) == 1
+    assert rows[0][0]
+
+
+@pytest.mark.skipif(utils.TEST_TD_3360, reason="skip for TD-3360")
+def test_consumer_with_adapter_ha_dsn():
+    init_topic()
+    try:
+        consumer = Consumer(
+            dsn=f"ws://{utils.test_username()}:{utils.test_password()}@localhost:6041?&group.id=3731&auto.offset.reset=earliest&adapter_ha=true"
+        )
+        assert_consumer_can_poll(consumer)
+    finally:
+        cleanup_topic()
+
+
+@pytest.mark.skipif(utils.TEST_TD_3360, reason="skip for TD-3360")
+def test_consumer_with_adapter_ha_conf():
+    init_topic()
+    try:
+        consumer = Consumer(
+            {
+                "td.connect.websocket.scheme": "ws",
+                "td.connect.ip": "localhost",
+                "td.connect.port": "6041",
+                "td.connect.user": utils.test_username(),
+                "td.connect.pass": utils.test_password(),
+                "group.id": "7616",
+                "auto.offset.reset": "earliest",
+                "adapter_ha": "true",
+            }
+        )
+        assert_consumer_can_poll(consumer)
+    finally:
+        cleanup_topic()
+
+
+def adapter_ha_connect():
+    return taosws.connect(
+        host="localhost",
+        port=6041,
+        user=utils.test_username(),
+        password=utils.test_password(),
+        adapter_ha="true",
+    )
+
+
+def init_topic():
+    cleanup_topic()
+    conn = adapter_ha_connect()
+    try:
+        cursor = conn.cursor()
+        statements = [
+            "create database test_1782722646",
+            "create topic topic_1782722646 as database test_1782722646",
+            "use test_1782722646",
+            "create table meters(ts timestamp, c1 int) tags(t1 int)",
+            "create table tb0 using meters tags(1000)",
+            "insert into tb0 values(now, 1)",
+        ]
+        for statement in statements:
+            cursor.execute(statement)
+    finally:
+        conn.close()
+
+
+def cleanup_topic():
+    for attempt in range(10):
+        conn = adapter_ha_connect()
+        try:
+            conn.execute(f"drop topic if exists topic_1782722646")
+            conn.execute(f"drop database if exists test_1782722646")
+            return
+        except Exception as err:
+            if "Topic subscribed cannot be dropped" not in str(err) or attempt == 9:
+                raise
+            time.sleep(1)
+        finally:
+            conn.close()
+
+
+def assert_consumer_can_poll(consumer):
+    try:
+        consumer.subscribe(["topic_1782722646"])
+        message = consumer.poll(timeout=1.0)
+        if message is not None:
+            for block in message:
+                assert block.nrows() >= 0
+    finally:
+        consumer.unsubscribe()
+        consumer.close()

--- a/tests/test_rest_connection.py
+++ b/tests/test_rest_connection.py
@@ -1,6 +1,7 @@
 import datetime
 import taosrest
 import os
+import pytest
 import utils
 from decorators import check_env
 from dotenv import load_dotenv
@@ -245,6 +246,7 @@ def test_tzinfo_timezone_with_req_id():
         # tzinfo=datetime.timezone(datetime.timedelta(seconds=28800), 'CST')), -100, -200.3]
 
 
+@pytest.mark.skip(reason="connects to public TDengine Cloud gateway; unreachable from internal CI runners")
 def test_wrong_token():
     try:
         conn = taosrest.connect(url="https://gw.us-east.azure.cloud.tdengine.com", token="wrong_token")
@@ -254,6 +256,7 @@ def test_wrong_token():
         assert e.status_code == 401
 
 
+@pytest.mark.skip(reason="connects to public TDengine Cloud gateway; unreachable from internal CI runners")
 def test_token():
     conn = taosrest.connect(
         url="https://gw.us-west-2.aws.cloud.tdengine.com", token="f158c322e165e82156f50ba4aa0f3e01081b38d7"

--- a/tests/test_tmq.py
+++ b/tests/test_tmq.py
@@ -526,7 +526,7 @@ def test_tmq_with_token():
 def test_tmq_with_invalid_token():
     pre_test_tmq("")
     try:
-        with pytest.raises(TmqError, match=r"init tscObj with token failed"):
+        with pytest.raises(TmqError, match=r"Invalid token"):
             Consumer(
                 {
                     "group.id": "token_test_group",


### PR DESCRIPTION
# Description

Sync the remaining TDengine subtree updates into the upstream Python connector repository.

This includes updated build and packaging documentation, local Rust connector path configuration for taos-ws-py, cargo-deny advisory/source adjustments, and test updates for internal CI compatibility.

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [ ] Are the test cases passed and automated?
- [ ] Is there no significant decrease in test coverage?